### PR TITLE
Alterado nome das portas de entrada

### DIFF
--- a/src/main/java/com/fiap/grupo186/techchallenge/application/handlers/CreateOrderHandler.java
+++ b/src/main/java/com/fiap/grupo186/techchallenge/application/handlers/CreateOrderHandler.java
@@ -1,6 +1,6 @@
-package com.fiap.grupo186.techchallenge.application.usecases;
+package com.fiap.grupo186.techchallenge.application.handlers;
 
-import com.fiap.grupo186.techchallenge.application.ports.CreatOrderPort;
+import com.fiap.grupo186.techchallenge.application.ports.CreatOrderUseCase;
 import com.fiap.grupo186.techchallenge.domains.kitchen.models.Order;
 import com.fiap.grupo186.techchallenge.domains.kitchen.services.KitchenService;
 import com.fiap.grupo186.techchallenge.application.dtos.PreOrderDTO;
@@ -8,12 +8,12 @@ import com.fiap.grupo186.techchallenge.application.ports.OrderRepositoryPort;
 import org.springframework.stereotype.Service;
 
 @Service
-public class CreateOrderUseCase implements CreatOrderPort {
+public class CreateOrderHandler implements CreatOrderUseCase {
     private final OrderRepositoryPort repository;
 
     private final KitchenService domainService;
 
-    public CreateOrderUseCase(OrderRepositoryPort repository, KitchenService domainService) {
+    public CreateOrderHandler(OrderRepositoryPort repository, KitchenService domainService) {
         this.repository = repository;
         this.domainService = domainService;
     }

--- a/src/main/java/com/fiap/grupo186/techchallenge/application/handlers/UpdateStatusOrderHandler.java
+++ b/src/main/java/com/fiap/grupo186/techchallenge/application/handlers/UpdateStatusOrderHandler.java
@@ -1,7 +1,7 @@
-package com.fiap.grupo186.techchallenge.application.usecases;
+package com.fiap.grupo186.techchallenge.application.handlers;
 
 import com.fiap.grupo186.techchallenge.application.ports.OrderRepositoryPort;
-import com.fiap.grupo186.techchallenge.application.ports.UpdateStatusOrderPort;
+import com.fiap.grupo186.techchallenge.application.ports.UpdateStatusOrderUseCase;
 import com.fiap.grupo186.techchallenge.domains.kitchen.models.OrderStatus;
 import com.fiap.grupo186.techchallenge.domains.kitchen.services.KitchenService;
 import org.springframework.stereotype.Service;
@@ -9,11 +9,11 @@ import org.springframework.stereotype.Service;
 import java.util.UUID;
 
 @Service
-public class UpdateStatusOrderUseCase implements UpdateStatusOrderPort {
+public class UpdateStatusOrderHandler implements UpdateStatusOrderUseCase {
     private final OrderRepositoryPort repository;
     private final KitchenService service;
 
-    public UpdateStatusOrderUseCase(OrderRepositoryPort repository, KitchenService service) {
+    public UpdateStatusOrderHandler(OrderRepositoryPort repository, KitchenService service) {
         this.repository = repository;
         this.service = service;
     }

--- a/src/main/java/com/fiap/grupo186/techchallenge/application/ports/CreatOrderUseCase.java
+++ b/src/main/java/com/fiap/grupo186/techchallenge/application/ports/CreatOrderUseCase.java
@@ -3,6 +3,6 @@ package com.fiap.grupo186.techchallenge.application.ports;
 import com.fiap.grupo186.techchallenge.application.dtos.PreOrderDTO;
 import com.fiap.grupo186.techchallenge.domains.kitchen.models.Order;
 
-public interface CreatOrderPort {
+public interface CreatOrderUseCase {
     Order execute(PreOrderDTO dto);
 }

--- a/src/main/java/com/fiap/grupo186/techchallenge/application/ports/UpdateStatusOrderUseCase.java
+++ b/src/main/java/com/fiap/grupo186/techchallenge/application/ports/UpdateStatusOrderUseCase.java
@@ -4,6 +4,6 @@ import com.fiap.grupo186.techchallenge.domains.kitchen.models.OrderStatus;
 
 import java.util.UUID;
 
-public interface UpdateStatusOrderPort {
+public interface UpdateStatusOrderUseCase {
     void execute(UUID orderId, OrderStatus status);
 }

--- a/src/main/java/com/fiap/grupo186/techchallenge/infrastructure/adapters/controllers/OrderController.java
+++ b/src/main/java/com/fiap/grupo186/techchallenge/infrastructure/adapters/controllers/OrderController.java
@@ -1,8 +1,8 @@
 package com.fiap.grupo186.techchallenge.infrastructure.adapters.controllers;
 
 import com.fiap.grupo186.techchallenge.application.dtos.UpdateStatusDTO;
-import com.fiap.grupo186.techchallenge.application.ports.CreatOrderPort;
-import com.fiap.grupo186.techchallenge.application.ports.UpdateStatusOrderPort;
+import com.fiap.grupo186.techchallenge.application.ports.CreatOrderUseCase;
+import com.fiap.grupo186.techchallenge.application.ports.UpdateStatusOrderUseCase;
 import com.fiap.grupo186.techchallenge.domains.kitchen.models.Order;
 import com.fiap.grupo186.techchallenge.application.dtos.PreOrderDTO;
 import io.swagger.v3.oas.annotations.Operation;
@@ -25,15 +25,15 @@ import static org.springframework.http.ResponseEntity.status;
 @RestController
 @RequestMapping("/orders")
 public class OrderController {
-    private final CreatOrderPort creatOrderPort;
-    private final UpdateStatusOrderPort updateStatusOrderPort;
+    private final CreatOrderUseCase creatOrderUseCase;
+    private final UpdateStatusOrderUseCase updateStatusOrderUseCase;
 
     public OrderController(
-        CreatOrderPort creatOrderPort,
-        UpdateStatusOrderPort updateStatusOrderPort
+        CreatOrderUseCase creatOrderUseCase,
+        UpdateStatusOrderUseCase updateStatusOrderUseCase
     ) {
-        this.creatOrderPort = creatOrderPort;
-        this.updateStatusOrderPort = updateStatusOrderPort;
+        this.creatOrderUseCase = creatOrderUseCase;
+        this.updateStatusOrderUseCase = updateStatusOrderUseCase;
     }
 
     @PostMapping
@@ -43,7 +43,7 @@ public class OrderController {
             @ApiResponse(responseCode = "400", description = "Invalid input data in request body")
     })
     public ResponseEntity<Order> createOrder(@RequestBody @Valid PreOrderDTO preOrder){
-        var order = creatOrderPort.execute(preOrder);
+        var order = creatOrderUseCase.execute(preOrder);
         return status(CREATED).body(order);
     }
 
@@ -57,7 +57,7 @@ public class OrderController {
         @PathVariable UUID id,
         @RequestBody @Valid UpdateStatusDTO dto) {
 
-        updateStatusOrderPort.execute(id, dto.status());
+        updateStatusOrderUseCase.execute(id, dto.status());
 
         return ResponseEntity.noContent().build();
     }


### PR DESCRIPTION
Observei que é um bom padrão manter as portas de entrada como "UseCases" e as classes de ação que vão orquestrar o fluxo estou chamando de "handlers" que vão implementar os UseCases 